### PR TITLE
Shutter by config

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -25,6 +25,7 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig, val configuration: Con
 
   val appName: String = servicesConfig.getString("appName")
   val shuttered: Boolean = configuration.getOptional[Boolean]("isShuttered").getOrElse(false)
+  val shutterMessage: Option[String] = configuration.getOptional[String]("shutterMessage")
   val authBaseUrl: String = servicesConfig.baseUrl("auth")
   val homeOfficeImmigrationStatusProxyBaseUrl: String = servicesConfig.baseUrl("home-office-immigration-status-proxy")
   val mongoSessionExpiration: Int = servicesConfig.getInt("mongodb.ttl.seconds")

--- a/app/views/ShutteringPage.scala.html
+++ b/app/views/ShutteringPage.scala.html
@@ -17,7 +17,8 @@
 @import config.AppConfig
 
 @this(
-    govukWrapper: govuk_wrapper
+    govukWrapper: govuk_wrapper,
+    appConfig: AppConfig
 )
 
 @()(implicit request: Request[_], messages: Messages)
@@ -26,7 +27,7 @@
 
     <h1 class="govuk-heading-xl" id="title">@messages("shuttering.title")</h1>
 
-    <p class="govuk-body">@messages("shuttering.message")</p>
+    <p class="govuk-body">@appConfig.shutterMessage.getOrElse(messages("shuttering.defaultMessage"))</p>
 
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -169,7 +169,7 @@ run.mode = "Dev"
 authorisedStrideGroup = "TBC"
 
 # Used to shutter the service. Should not be changed here, instead add `isShuttered: 'true'` to app-config-<env> and redeploy.
-isShuttered = false
+isShuttered = true
 
 json.encryption.key = "UrI5kMAs7ewjByGBXD2+5+v3GZdCzutjTe07g37xc2M="
 

--- a/conf/messages
+++ b/conf/messages
@@ -168,7 +168,7 @@ internal.error.500.message='Contact the Helpline.'
 
 # Shuttering
 shuttering.title='Sorry, the service is unavailable'
-shuttering.message='Try again later.'
+shuttering.defaultMessage='Try again later.'
 
 # Accessibility
 accessibility.title='Accessibility statement for check immigration status'

--- a/test/controllers/actions/ShutterActionSpec.scala
+++ b/test/controllers/actions/ShutterActionSpec.scala
@@ -66,7 +66,7 @@ class ShutterActionSpec extends ControllerSpec {
 
   "applyFiltering" must {
 
-    "don't filter where shuttered is false" in {
+    "not filter where shuttered is false" in {
       when(mockAppConfig.shuttered).thenReturn(false)
       val fut = shutterAction.invokeBlock(request, block)
       contentAsString(fut) mustEqual "Invoked"
@@ -74,6 +74,7 @@ class ShutterActionSpec extends ControllerSpec {
 
     "filter to the shutter page where shuttered is true" in {
       when(mockAppConfig.shuttered).thenReturn(true)
+      when(mockAppConfig.shutterMessage).thenReturn(None)
       val fut = shutterAction.invokeBlock(request, block)
       contentAsString(fut) mustEqual shutteringPage().toString
     }

--- a/test/views/ShutterPageViewSpec.scala
+++ b/test/views/ShutterPageViewSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import config.AppConfig
+import org.mockito.Mockito.{mock, when}
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import views.html.ShutteringPage
+
+class ShutterPageViewSpec extends ViewSpec {
+
+  val mockAppConfig: AppConfig = mock(classOf[AppConfig])
+
+  override implicit lazy val app: Application = new GuiceApplicationBuilder()
+    .overrides(
+      bind[AppConfig].toInstance(mockAppConfig)
+    )
+    .build()
+
+  val providedShutterMessage = "[the provided message]"
+
+  lazy val sut: ShutteringPage = inject[ShutteringPage]
+
+  "apply" when {
+    "a shutter message is provided" must {
+      when(mockAppConfig.shutterMessage).thenReturn(Some(providedShutterMessage))
+      val doc = asDocument(sut()(request, messages))
+
+      "have the title" in {
+        doc.getElementsByTag("h1").text() mustBe messages("shuttering.title")
+      }
+
+      "use the provided message" in {
+        doc.html() must include(providedShutterMessage)
+        doc.html() must not include messages("shuttering.defaultMessage")
+      }
+    }
+    "no shutter message is provided" must {
+      when(mockAppConfig.shutterMessage).thenReturn(None)
+      val doc = asDocument(sut()(request, messages))
+
+      "use the default message" in {
+        doc.html() must include(messages("shuttering.defaultMessage"))
+        doc.html() must not include providedShutterMessage
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Will need to add the current shutter message "You will be able to use the service from 10am on Tuesday 4 January 2022." to app-config-prod before this is deployed